### PR TITLE
Pass access token in Authorization header

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -17,15 +17,15 @@ var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `consumerKey`     identifies client to Fitbit
- *   - `consumerSecret`  secret used to establish ownership of the consumer key
- *   - `callbackURL`     URL to which Fitbit will redirect the user after obtaining authorization
+ *   - `clientID`        identifies client for Planning Center
+ *   - `clientSecret`    client secret for the given client
+ *   - `callbackURL`     URL to which Planning Center will redirect the user after obtaining authorization
  *
  * Examples:
  *
  *     passport.use(new PlanningCenterOauth2Strategy({
- *         consumerKey: '123-456-789',
- *         consumerSecret: 'shhh-its-a-secret'
+ *         clientID: '123-456-789',
+ *         callbackURL: 'shhh-its-a-secret'
  *         callbackURL: 'https://www.example.net/auth/planningcenter/callback'
  *       },
  *       function(token, tokenSecret, profile, done) {
@@ -50,6 +50,7 @@ function Strategy(options, verify) {
   OAuth2Strategy.call(this, options, verify);
   this._profileURL = options.profileURL || 'https://api.planningcenteronline.com/people/v2/me';
   this.name = 'planningcenter-oauth2';
+  this._oauth2.useAuthorizationHeaderforGET(true);
 }
 
 


### PR DESCRIPTION
When fetching the user profile, the access token is being passed in the query string, which returns a `status: 401 data: HTTP Basic: Access denied` from planning center.

This PR makes the call to use `Authorization` header instead.